### PR TITLE
Moved table header menu icon to the right side

### DIFF
--- a/openlab/frontend/src/pages/indicator-specification-cards/creator/components/dataset/data-table-manager/data-table-manager.jsx
+++ b/openlab/frontend/src/pages/indicator-specification-cards/creator/components/dataset/data-table-manager/data-table-manager.jsx
@@ -31,7 +31,7 @@ const DataTableManager = () => {
       "& .MuiDataGrid-columnHeaders": {
         cursor: "pointer",
         fontSize: "17px",
-        textDecorationLine: "underline",
+        // textDecorationLine: "underline",
       },
       "& .MuiDataGrid-cell:hover": {
         color: "primary.main",
@@ -147,6 +147,19 @@ const DataTableManager = () => {
     state.page * state.pageSize,
   );
 
+  const columnTypeLabel = dataset.columns.map((col) => {
+    const headerLabel = col.type === "string" ? "Categorical" : "Numerical";
+    return {
+      ...col,
+      renderHeader: (params) => (
+        <div style={{display: "flex", flexDirection: "column", alignItems: "flex-start"}}>
+          <span style={{textDecorationLine: "underline"}}>{params.colDef.headerName}</span>
+          <small style={{fontSize: "0.7rem", color: "#999"}}>{headerLabel}</small>
+        </div>
+      ),
+    };
+  });
+  
   return (
     <>
       <Grid container spacing={2}>
@@ -155,7 +168,7 @@ const DataTableManager = () => {
         </Grid>
         <Grid item xs={12}>
           <DataGrid
-            columns={dataset.columns}
+            columns={columnTypeLabel}
             rows={paginatedRows}
             apiRef={apiRef}
             columnMenuClearIcon={<ClearAllIcon />}

--- a/openlab/frontend/src/pages/indicator-specification-cards/creator/components/dataset/data-table-manager/data-table-manager.jsx
+++ b/openlab/frontend/src/pages/indicator-specification-cards/creator/components/dataset/data-table-manager/data-table-manager.jsx
@@ -149,8 +149,10 @@ const DataTableManager = () => {
 
   const columnTypeLabel = dataset.columns.map((col) => {
     const headerLabel = col.type === "string" ? "Categorical" : "Numerical";
+    const isNumber = col.type === "number";
     return {
       ...col,
+      ...(isNumber ? {align:"left", headerAlign: "left"} : {}),
       renderHeader: (params) => (
         <div style={{display: "flex", flexDirection: "column", alignItems: "flex-start"}}>
           <span style={{textDecorationLine: "underline"}}>{params.colDef.headerName}</span>

--- a/openlab/frontend/src/pages/indicator-specification-cards/creator/components/finalize/components/bar-chart.jsx
+++ b/openlab/frontend/src/pages/indicator-specification-cards/creator/components/finalize/components/bar-chart.jsx
@@ -384,18 +384,39 @@ const BarChart = ({ customize = false, handleToggleCustomizePanel }) => {
     }));
   };
 
+  // Get selected column
+  const selectedXAxisColumn = state.axisOptions.xAxisOptions.find(
+    (col) => col.field === state.axisOptions.selectedXAxis
+  );
+
+  const selectedYAxisColumn = state.axisOptions.yAxisOptions.find(
+    (col) => col.field === state.axisOptions.selectedYAxis
+  );
+
+  // Determine the label to show based on the column type
+  const xAxisColumnType = selectedXAxisColumn
+    ? (selectedXAxisColumn.type === "string" ? "Categorical" : "Numerical")
+    : "Unknown"; // optional fallback if no column is selected
+
+  const yAxisColumnType = selectedYAxisColumn
+    ? (selectedYAxisColumn.type === "string" ? "Categorical" : "Numerical")
+    : "Unknown"; // optional fallback if no column is selected
+
+  const xAxisLabel = `X-Axis (${xAxisColumnType})`;
+  const yAxisLabel = `Y-Axis (${yAxisColumnType})`;
+
   return (
     <>
       <Grid container spacing={2}>
         <Grid size={{ xs: 12, md: 6 }}>
           <FormControl fullWidth>
-            <InputLabel id="x-axis-select-label">X-Axis</InputLabel>
+            <InputLabel id="x-axis-select-label">{xAxisLabel}</InputLabel>
             <Select
               labelId="x-axis-select-label"
               id="x-axis-select"
               value={state.axisOptions.selectedXAxis}
               onChange={handleXAxisChange}
-              label="X-Axis"
+              label={xAxisLabel}
               variant="outlined"
             >
               {state.axisOptions.xAxisOptions.map((col) => (
@@ -408,13 +429,13 @@ const BarChart = ({ customize = false, handleToggleCustomizePanel }) => {
         </Grid>
         <Grid size={{ xs: 12, md: 6 }}>
           <FormControl fullWidth>
-            <InputLabel id="y-axis-select-label">Y-Axis</InputLabel>
+            <InputLabel id="y-axis-select-label">{yAxisLabel}</InputLabel>
             <Select
               labelId="y-axis-select-label"
               id="y-axis-select"
               value={state.axisOptions.selectedYAxis}
               onChange={handleYAxisChange}
-              label="Y-Axis"
+              label={yAxisLabel}
               variant="outlined"
             >
               {state.axisOptions.yAxisOptions.map((col) => (

--- a/openlab/frontend/src/pages/indicator-specification-cards/creator/components/finalize/components/dot-chart.jsx
+++ b/openlab/frontend/src/pages/indicator-specification-cards/creator/components/finalize/components/dot-chart.jsx
@@ -350,18 +350,39 @@ const DotChart = ({ customize = false, handleToggleCustomizePanel }) => {
     }));
   };
 
+  // Get selected column
+  const selectedXAxisColumn = state.axisOptions.xAxisOptions.find(
+    (col) => col.field === state.axisOptions.selectedXAxis
+  );
+
+  const selectedYAxisColumn = state.axisOptions.yAxisOptions.find(
+    (col) => col.field === state.axisOptions.selectedYAxis
+  );
+
+  // Determine the label to show based on the column type
+  const xAxisColumnType = selectedXAxisColumn
+    ? (selectedXAxisColumn.type === "string" ? "Categorical" : "Numerical")
+    : "Unknown"; // optional fallback if no column is selecte
+
+  const yAxisColumnType = selectedYAxisColumn
+    ? (selectedYAxisColumn.type === "string" ? "Categorical" : "Numerical")
+    : "Unknown"; // optional fallback if no column is selected
+
+  const xAxisLabel = `X-Axis (${xAxisColumnType})`;
+  const yAxisLabel = `Y-Axis (${yAxisColumnType})`;
+
   return (
     <>
       <Grid container spacing={2}>
         <Grid size={{ xs: 12, md: 6 }}>
           <FormControl fullWidth>
-            <InputLabel id="x-axis-select-label">X-Axis</InputLabel>
+            <InputLabel id="x-axis-select-label">{xAxisLabel}</InputLabel>
             <Select
               labelId="x-axis-select-label"
               id="x-axis-select"
               value={state.axisOptions.selectedXAxis}
               onChange={handleXAxisChange}
-              label="X-Axis"
+              label={xAxisLabel}
               variant="outlined"
             >
               {state.axisOptions.xAxisOptions.map((col) => (
@@ -374,13 +395,13 @@ const DotChart = ({ customize = false, handleToggleCustomizePanel }) => {
         </Grid>
         <Grid size={{ xs: 12, md: 6 }}>
           <FormControl fullWidth>
-            <InputLabel id="y-axis-select-label">Y-Axis</InputLabel>
+            <InputLabel id="y-axis-select-label">{yAxisLabel}</InputLabel>
             <Select
               labelId="y-axis-select-label"
               id="y-axis-select"
               value={state.axisOptions.selectedYAxis}
               onChange={handleYAxisChange}
-              label="Y-Axis"
+              label={yAxisLabel}
               variant="outlined"
             >
               {state.axisOptions.yAxisOptions.map((col) => (

--- a/openlab/frontend/src/pages/indicator-specification-cards/creator/components/finalize/components/grouped-bar-chart.jsx
+++ b/openlab/frontend/src/pages/indicator-specification-cards/creator/components/finalize/components/grouped-bar-chart.jsx
@@ -352,18 +352,39 @@ const GroupedBarChart = ({ customize = false, handleToggleCustomizePanel }) => {
     localStorage.removeItem("series");
   };
 
+  // Get selected column
+  const selectedXAxisColumn = state.axisOptions.xAxisOptions.find(
+    (col) => col.field === state.axisOptions.selectedXAxis
+  );
+
+  // Determine the label to show based on the column type
+  const xAxisColumnType = selectedXAxisColumn
+    ? (selectedXAxisColumn.type === "string" ? "Categorical" : "Numerical")
+    : "Unknown"; // optional fallback if no column is selected
+
+  // If multiple data selected
+  const selectedYAxesColumns = (state.axisOptions.selectedYAxis || []).map((field) => {
+  const col = state.axisOptions.yAxisOptions.find((c) => c.field === field);
+    return col?.type === "string" ? "Categorical" : "Numerical";
+  });
+
+  const yAxesColumnTypes = [...new Set(selectedYAxesColumns)].join(", "); // remove duplicates
+
+  const xAxisLabel = `X-Axis (${xAxisColumnType})`;
+  const yAxesLabel = `Y-Axes (${yAxesColumnTypes})`;
+
   return (
     <>
       <Grid container spacing={2}>
         <Grid size={{ xs: 12, md: 6 }}>
           <FormControl fullWidth>
-            <InputLabel id="x-axis-select-label">X-Axis</InputLabel>
+            <InputLabel id="x-axis-select-label">{xAxisLabel}</InputLabel>
             <Select
               labelId="x-axis-select-label"
               id="x-axis-select"
               value={state.axisOptions.selectedXAxis}
               onChange={handleXAxisChange}
-              label="X-Axis"
+              label={xAxisLabel}
               variant="outlined"
             >
               {state.axisOptions.xAxisOptions.map((col) => (
@@ -376,14 +397,14 @@ const GroupedBarChart = ({ customize = false, handleToggleCustomizePanel }) => {
         </Grid>
         <Grid size={{ xs: 12, md: 6 }}>
           <FormControl fullWidth>
-            <InputLabel id="y-axes-select-label">Y-Axes</InputLabel>
+            <InputLabel id="y-axes-select-label">{yAxesLabel}</InputLabel>
             <Select
               labelId="y-axes-select-label"
               id="y-axes-select"
               multiple
               value={state.axisOptions.selectedYAxis}
               onChange={handleYAxesChange}
-              label="Y-Axes"
+              label={yAxesLabel}
               variant="outlined"
               renderValue={(selected) =>
                 selected

--- a/openlab/frontend/src/pages/indicator-specification-cards/creator/components/finalize/components/line-chart.jsx
+++ b/openlab/frontend/src/pages/indicator-specification-cards/creator/components/finalize/components/line-chart.jsx
@@ -352,18 +352,39 @@ const LineChart = ({ customize = false, handleToggleCustomizePanel }) => {
     localStorage.removeItem("series");
   };
 
+  // Get selected column
+  const selectedXAxisColumn = state.axisOptions.xAxisOptions.find(
+    (col) => col.field === state.axisOptions.selectedXAxis
+  );
+
+  // Determine the label to show based on the column type
+  const xAxisColumnType = selectedXAxisColumn
+    ? (selectedXAxisColumn.type === "string" ? "Categorical" : "Numerical")
+    : "Unknown"; // optional fallback if no column is selected
+
+  // If multiple data selected
+  const selectedYAxesColumns = (state.axisOptions.selectedYAxis || []).map((field) => {
+  const col = state.axisOptions.yAxisOptions.find((c) => c.field === field);
+    return col?.type === "string" ? "Categorical" : "Numerical";
+  });
+
+  const yAxesColumnTypes = [...new Set(selectedYAxesColumns)].join(", "); // remove duplicates
+
+  const xAxisLabel = `X-Axis (${xAxisColumnType})`;
+  const yAxesLabel = `Y-Axes (${yAxesColumnTypes})`;
+
   return (
     <>
       <Grid container spacing={2}>
         <Grid size={{ xs: 12, md: 6 }}>
           <FormControl fullWidth>
-            <InputLabel id="x-axis-select-label">X-Axis</InputLabel>
+            <InputLabel id="x-axis-select-label">{xAxisLabel}</InputLabel>
             <Select
               labelId="x-axis-select-label"
               id="x-axis-select"
               value={state.axisOptions.selectedXAxis}
               onChange={handleXAxisChange}
-              label="X-Axis"
+              label={xAxisLabel}
               variant="outlined"
             >
               {state.axisOptions.xAxisOptions.map((col) => (
@@ -376,14 +397,14 @@ const LineChart = ({ customize = false, handleToggleCustomizePanel }) => {
         </Grid>
         <Grid size={{ xs: 12, md: 6 }}>
           <FormControl fullWidth>
-            <InputLabel id="y-axes-select-label">Y-Axes</InputLabel>
+            <InputLabel id="y-axes-select-label">{yAxesLabel}</InputLabel>
             <Select
               labelId="y-axes-select-label"
               id="y-axes-select"
               multiple
               value={state.axisOptions.selectedYAxis}
               onChange={handleYAxesChange}
-              label="Y-Axes"
+              label={yAxesLabel}
               variant="outlined"
               renderValue={(selected) =>
                 selected

--- a/openlab/frontend/src/pages/indicator-specification-cards/creator/components/finalize/components/pie-chart.jsx
+++ b/openlab/frontend/src/pages/indicator-specification-cards/creator/components/finalize/components/pie-chart.jsx
@@ -331,19 +331,6 @@ const PieChart = ({ customize = false, handleToggleCustomizePanel }) => {
     }));
   };
 
-  const columnTypeLabel = dataset.columns.map((col) => {
-    const headerLabel = col.type === "string" ? "Categorical" : "Numerical";
-    return {
-      ...col,
-      renderHeader: (params) => (
-        <div style={{display: "flex", flexDirection: "column", alignItems: "flex-start"}}>
-          <span style={{textDecorationLine: "underline"}}>{params.colDef.headerName}</span>
-          <small style={{fontSize: "0.7rem", color: "#999"}}>{headerLabel}</small>
-        </div>
-      ),
-    };
-  });
-
 // Get selected column
   const selectedXAxisColumn = state.axisOptions.xAxisOptions.find(
     (col) => col.field === state.axisOptions.selectedXAxis

--- a/openlab/frontend/src/pages/indicator-specification-cards/creator/components/finalize/components/pie-chart.jsx
+++ b/openlab/frontend/src/pages/indicator-specification-cards/creator/components/finalize/components/pie-chart.jsx
@@ -331,18 +331,52 @@ const PieChart = ({ customize = false, handleToggleCustomizePanel }) => {
     }));
   };
 
+  const columnTypeLabel = dataset.columns.map((col) => {
+    const headerLabel = col.type === "string" ? "Categorical" : "Numerical";
+    return {
+      ...col,
+      renderHeader: (params) => (
+        <div style={{display: "flex", flexDirection: "column", alignItems: "flex-start"}}>
+          <span style={{textDecorationLine: "underline"}}>{params.colDef.headerName}</span>
+          <small style={{fontSize: "0.7rem", color: "#999"}}>{headerLabel}</small>
+        </div>
+      ),
+    };
+  });
+
+// Get selected column
+  const selectedXAxisColumn = state.axisOptions.xAxisOptions.find(
+    (col) => col.field === state.axisOptions.selectedXAxis
+  );
+
+  const selectedYAxisColumn = state.axisOptions.yAxisOptions.find(
+    (col) => col.field === state.axisOptions.selectedYAxis
+  );
+
+  // Determine the label to show based on the column type
+  const xAxisColumnType = selectedXAxisColumn
+    ? (selectedXAxisColumn.type === "string" ? "Categorical" : "Numerical")
+    : "Unknown"; // optional fallback if no column is selecte
+
+  const yAxisColumnType = selectedYAxisColumn
+    ? (selectedYAxisColumn.type === "string" ? "Categorical" : "Numerical")
+    : "Unknown"; // optional fallback if no column is selected
+
+  const xAxisLabel = `Categories (${xAxisColumnType})`;
+  const yAxisLabel = `Values (${yAxisColumnType})`;
+
   return (
     <>
       <Grid container spacing={2}>
         <Grid size={{ xs: 12, md: 6 }}>
           <FormControl fullWidth>
-            <InputLabel id="x-axis-select-label">Categories</InputLabel>
+            <InputLabel id="x-axis-select-label">{xAxisLabel}</InputLabel>
             <Select
               labelId="x-axis-select-label"
               id="x-axis-select"
               value={state.axisOptions.selectedXAxis}
               onChange={handleXAxisChange}
-              label="Categories"
+              label={xAxisLabel}
               variant="outlined"
             >
               {state.axisOptions.xAxisOptions.map((col) => (
@@ -355,13 +389,13 @@ const PieChart = ({ customize = false, handleToggleCustomizePanel }) => {
         </Grid>
         <Grid size={{ xs: 12, md: 6 }}>
           <FormControl fullWidth>
-            <InputLabel id="y-axis-select-label">Values</InputLabel>
+            <InputLabel id="y-axis-select-label">{yAxisLabel}</InputLabel>
             <Select
               labelId="y-axis-select-label"
               id="y-axis-select"
               value={state.axisOptions.selectedYAxis}
               onChange={handleYAxisChange}
-              label="Values"
+              label={yAxisLabel}
               variant="outlined"
             >
               {state.axisOptions.yAxisOptions.map((col) => (

--- a/openlab/frontend/src/pages/indicator-specification-cards/creator/components/finalize/components/polar-area-chart.jsx
+++ b/openlab/frontend/src/pages/indicator-specification-cards/creator/components/finalize/components/polar-area-chart.jsx
@@ -331,18 +331,39 @@ const PolarAreaChart = ({ customize = false, handleToggleCustomizePanel }) => {
     }));
   };
 
+  // Get selected column
+  const selectedXAxisColumn = state.axisOptions.xAxisOptions.find(
+    (col) => col.field === state.axisOptions.selectedXAxis
+  );
+
+  const selectedYAxisColumn = state.axisOptions.yAxisOptions.find(
+    (col) => col.field === state.axisOptions.selectedYAxis
+  );
+
+  // Determine the label to show based on the column type
+  const xAxisColumnType = selectedXAxisColumn
+    ? (selectedXAxisColumn.type === "string" ? "Categorical" : "Numerical")
+    : "Unknown"; // optional fallback if no column is selecte
+
+  const yAxisColumnType = selectedYAxisColumn
+    ? (selectedYAxisColumn.type === "string" ? "Categorical" : "Numerical")
+    : "Unknown"; // optional fallback if no column is selected
+
+  const xAxisLabel = `Categories (${xAxisColumnType})`;
+  const yAxisLabel = `Values (${yAxisColumnType})`;
+
   return (
     <>
       <Grid container spacing={2}>
         <Grid size={{ xs: 12, md: 6 }}>
           <FormControl fullWidth>
-            <InputLabel id="x-axis-select-label">Categories</InputLabel>
+            <InputLabel id="x-axis-select-label">{xAxisLabel}</InputLabel>
             <Select
               labelId="x-axis-select-label"
               id="x-axis-select"
               value={state.axisOptions.selectedXAxis}
               onChange={handleXAxisChange}
-              label="Categories"
+              label={xAxisLabel}
               variant="outlined"
             >
               {state.axisOptions.xAxisOptions.map((col) => (
@@ -355,13 +376,13 @@ const PolarAreaChart = ({ customize = false, handleToggleCustomizePanel }) => {
         </Grid>
         <Grid size={{ xs: 12, md: 6 }}>
           <FormControl fullWidth>
-            <InputLabel id="y-axis-select-label">Values</InputLabel>
+            <InputLabel id="y-axis-select-label">{yAxisLabel}</InputLabel>
             <Select
               labelId="y-axis-select-label"
               id="y-axis-select"
               value={state.axisOptions.selectedYAxis}
               onChange={handleYAxisChange}
-              label="Values"
+              label={yAxisLabel}
               variant="outlined"
             >
               {state.axisOptions.yAxisOptions.map((col) => (

--- a/openlab/frontend/src/pages/indicator-specification-cards/creator/components/finalize/components/radar-chart.jsx
+++ b/openlab/frontend/src/pages/indicator-specification-cards/creator/components/finalize/components/radar-chart.jsx
@@ -351,18 +351,52 @@ const RadarChart = ({ customize = false, handleToggleCustomizePanel }) => {
     }));
   };
 
+  const columnTypeLabel = dataset.columns.map((col) => {
+    const headerLabel = col.type === "string" ? "Categorical" : "Numerical";
+    return {
+      ...col,
+      renderHeader: (params) => (
+        <div style={{display: "flex", flexDirection: "column", alignItems: "flex-start"}}>
+          <span style={{textDecorationLine: "underline"}}>{params.colDef.headerName}</span>
+          <small style={{fontSize: "0.7rem", color: "#999"}}>{headerLabel}</small>
+        </div>
+      ),
+    };
+  });
+
+  // Get selected column
+  const selectedXAxisColumn = state.axisOptions.xAxisOptions.find(
+    (col) => col.field === state.axisOptions.selectedXAxis
+  );
+
+  // Determine the label to show based on the column type
+  const xAxisColumnType = selectedXAxisColumn
+    ? (selectedXAxisColumn.type === "string" ? "Categorical" : "Numerical")
+    : "Unknown"; // optional fallback if no column is selecte
+
+  // If multiple data selected
+  const selectedYAxesColumns = (state.axisOptions.selectedYAxis || []).map((field) => {
+  const col = state.axisOptions.yAxisOptions.find((c) => c.field === field);
+    return col?.type === "string" ? "Categorical" : "Numerical";
+  });
+
+  const yAxesColumnTypes = [...new Set(selectedYAxesColumns)].join(", "); // remove duplicates
+
+  const xAxisLabel = `X-Axis (${xAxisColumnType})`;
+  const yAxisLabel = `Y-Axes (${yAxesColumnTypes})`;
+
   return (
     <>
       <Grid container spacing={2}>
         <Grid size={{ xs: 12, md: 6 }}>
           <FormControl fullWidth>
-            <InputLabel id="x-axis-select-label">X-Axis</InputLabel>
+            <InputLabel id="x-axis-select-label">{xAxisLabel}</InputLabel>
             <Select
               labelId="x-axis-select-label"
               id="x-axis-select"
               value={state.axisOptions.selectedXAxis}
               onChange={handleXAxisChange}
-              label="X-Axis"
+              label={xAxisLabel}
               variant="outlined"
             >
               {state.axisOptions.xAxisOptions.map((col) => (
@@ -375,14 +409,14 @@ const RadarChart = ({ customize = false, handleToggleCustomizePanel }) => {
         </Grid>
         <Grid size={{ xs: 12, md: 6 }}>
           <FormControl fullWidth>
-            <InputLabel id="y-axis-select-label">Y-Axis</InputLabel>
+            <InputLabel id="y-axis-select-label">{yAxisLabel}</InputLabel>
             <Select
               labelId="y-axis-select-label"
               id="y-axis-select"
               multiple
               value={state.axisOptions.selectedYAxis}
               onChange={handleYAxisChange}
-              label="Y-Axis"
+              label={yAxisLabel}
               variant="outlined"
               renderValue={(selected) =>
                 selected

--- a/openlab/frontend/src/pages/indicator-specification-cards/creator/components/finalize/components/radar-chart.jsx
+++ b/openlab/frontend/src/pages/indicator-specification-cards/creator/components/finalize/components/radar-chart.jsx
@@ -351,19 +351,6 @@ const RadarChart = ({ customize = false, handleToggleCustomizePanel }) => {
     }));
   };
 
-  const columnTypeLabel = dataset.columns.map((col) => {
-    const headerLabel = col.type === "string" ? "Categorical" : "Numerical";
-    return {
-      ...col,
-      renderHeader: (params) => (
-        <div style={{display: "flex", flexDirection: "column", alignItems: "flex-start"}}>
-          <span style={{textDecorationLine: "underline"}}>{params.colDef.headerName}</span>
-          <small style={{fontSize: "0.7rem", color: "#999"}}>{headerLabel}</small>
-        </div>
-      ),
-    };
-  });
-
   // Get selected column
   const selectedXAxisColumn = state.axisOptions.xAxisOptions.find(
     (col) => col.field === state.axisOptions.selectedXAxis

--- a/openlab/frontend/src/pages/indicator-specification-cards/creator/components/finalize/components/scatter-plot-chart.jsx
+++ b/openlab/frontend/src/pages/indicator-specification-cards/creator/components/finalize/components/scatter-plot-chart.jsx
@@ -418,18 +418,48 @@ const ScatterPlotChart = ({
     }));
   };
 
+  // Get selected column
+  const selectedXAxisColumn = state.axisOptions.xAxisOptions.find(
+    (col) => col.field === state.axisOptions.selectedXAxis
+  );
+
+  const selectedYAxisColumn = state.axisOptions.yAxisOptions.find(
+    (col) => col.field === state.axisOptions.selectedYAxis
+  );
+
+  const selectedLabelColumn = state.axisOptions.labelOptions.find(
+    (col) => col.field === state.axisOptions.selectedLabel
+  );
+
+  // Determine the label to show based on the column type
+  const xAxisColumnType = selectedXAxisColumn
+    ? (selectedXAxisColumn.type === "string" ? "Categorical" : "Numerical")
+    : "Unknown"; // optional fallback if no column is selecte
+
+  const yAxisColumnType = selectedYAxisColumn
+    ? (selectedYAxisColumn.type === "string" ? "Categorical" : "Numerical")
+    : "Unknown"; // optional fallback if no column is selected
+
+  const labelColumnType = selectedLabelColumn
+    ? (selectedLabelColumn.type === "string" ? "Categorical" : "Numerical")
+    : "Unknown"; // optional fallback if no column is selected
+
+  const xAxisLabel = `X-Axis (${xAxisColumnType})`;
+  const yAxisLabel = `Y-Axis (${yAxisColumnType})`;
+  const labels = `Labels (${labelColumnType})`;
+
   return (
     <>
       <Grid container spacing={2}>
         <Grid size={{ xs: 12, md: 4 }}>
           <FormControl fullWidth>
-            <InputLabel id="x-axis-select-label">X Axis</InputLabel>
+            <InputLabel id="x-axis-select-label">{xAxisLabel}</InputLabel>
             <Select
               labelId="x-axis-select-label"
               id="x-axis-select"
               value={state.axisOptions.selectedXAxis}
               onChange={handleXAxisChange}
-              label="X Axis"
+              label={xAxisLabel}
               variant="outlined"
             >
               {state.axisOptions.xAxisOptions.map((col) => (
@@ -442,13 +472,13 @@ const ScatterPlotChart = ({
         </Grid>
         <Grid size={{ xs: 12, md: 4 }}>
           <FormControl fullWidth>
-            <InputLabel id="y-axis-select-label">Y Axis</InputLabel>
+            <InputLabel id="y-axis-select-label">{yAxisLabel}</InputLabel>
             <Select
               labelId="y-axis-select-label"
               id="y-axis-select"
               value={state.axisOptions.selectedYAxis}
               onChange={handleYAxisChange}
-              label="Y Axis"
+              label={yAxisLabel}
               variant="outlined"
             >
               {state.axisOptions.yAxisOptions.map((col) => (
@@ -461,13 +491,13 @@ const ScatterPlotChart = ({
         </Grid>
         <Grid size={{ xs: 12, md: 4 }}>
           <FormControl fullWidth>
-            <InputLabel id="label-select-label">Labels</InputLabel>
+            <InputLabel id="label-select-label">{labels}</InputLabel>
             <Select
               labelId="label-select-label"
               id="label-select"
               value={state.axisOptions.selectedLabel}
               onChange={handleLabelChange}
-              label="Labels"
+              label={labels}
               variant="outlined"
             >
               {state.axisOptions.labelOptions.map((col) => (

--- a/openlab/frontend/src/pages/indicator-specification-cards/creator/components/finalize/components/stacked-bar-chart.jsx
+++ b/openlab/frontend/src/pages/indicator-specification-cards/creator/components/finalize/components/stacked-bar-chart.jsx
@@ -434,18 +434,48 @@ const StackedBarChart = ({ customize = false, handleToggleCustomizePanel }) => {
     }));
   };
 
+  // Get selected column
+  const selectedXAxisColumn = state.axisOptions.xAxisOptions.find(
+    (col) => col.field === state.axisOptions.selectedXAxis
+  );
+
+  const selectedYAxisColumn = state.axisOptions.yAxisOptions.find(
+    (col) => col.field === state.axisOptions.selectedYAxis
+  );
+
+  const selectedStackColumn = state.axisOptions.barValueOptions.find(
+    (col) => col.field === state.axisOptions.selectedBarValue
+  );
+
+  // Determine the label to show based on the column type
+  const xAxisColumnType = selectedXAxisColumn
+    ? (selectedXAxisColumn.type === "string" ? "Categorical" : "Numerical")
+    : "Unknown"; // optional fallback if no column is selecte
+
+  const yAxisColumnType = selectedYAxisColumn
+    ? (selectedYAxisColumn.type === "string" ? "Categorical" : "Numerical")
+    : "Unknown"; // optional fallback if no column is selected
+
+  const stackColumnType = selectedStackColumn
+    ? (selectedStackColumn.type === "string" ? "Categorical" : "Numerical")
+    : "Unknown"; // optional fallback if no column is selected
+
+  const xAxisLabel = `X-Axis: Group By (${xAxisColumnType})`;
+  const yAxisLabel = `Y-Axis (${yAxisColumnType})`;
+  const stackLabel = `Stack Label (${stackColumnType})`;
+
   return (
     <>
       <Grid container spacing={2}>
         <Grid size={{ xs: 12, md: 4 }}>
           <FormControl fullWidth>
-            <InputLabel id="x-axis-select-label">X-Axis: Group By</InputLabel>
+            <InputLabel id="x-axis-select-label">{xAxisLabel}</InputLabel>
             <Select
               labelId="x-axis-select-label"
               id="x-axis-select"
               value={state.axisOptions.selectedXAxis}
               onChange={handleXAxisChange}
-              label="X-Axis: Group By"
+              label={xAxisLabel}
               variant="outlined"
             >
               {state.axisOptions.xAxisOptions.map((col) => (
@@ -458,13 +488,13 @@ const StackedBarChart = ({ customize = false, handleToggleCustomizePanel }) => {
         </Grid>
         <Grid size={{ xs: 12, md: 4 }}>
           <FormControl fullWidth>
-            <InputLabel id="bar-value-select-label">Stack Label</InputLabel>
+            <InputLabel id="bar-value-select-label">{stackLabel}</InputLabel>
             <Select
               labelId="bar-value-select-label"
               id="bar-value-select"
               value={state.axisOptions.selectedBarValue}
               onChange={handleBarValueChange}
-              label="Stack Label"
+              label={stackLabel}
               variant="outlined"
             >
               {state.axisOptions.barValueOptions.map((col) => (
@@ -477,13 +507,13 @@ const StackedBarChart = ({ customize = false, handleToggleCustomizePanel }) => {
         </Grid>
         <Grid size={{ xs: 12, md: 4 }}>
           <FormControl fullWidth>
-            <InputLabel id="y-axis-select-label">Y-Axis</InputLabel>
+            <InputLabel id="y-axis-select-label">{yAxisLabel}</InputLabel>
             <Select
               labelId="y-axis-select-label"
               id="y-axis-select"
               value={state.axisOptions.selectedYAxis}
               onChange={handleYAxisChange}
-              label="Y-Axis"
+              label={yAxisLabel}
               variant="outlined"
             >
               {state.axisOptions.yAxisOptions.map((col) => (

--- a/openlab/frontend/src/pages/indicator-specification-cards/creator/components/finalize/components/treemap.jsx
+++ b/openlab/frontend/src/pages/indicator-specification-cards/creator/components/finalize/components/treemap.jsx
@@ -373,18 +373,48 @@ const TreeMap = ({ customize = false, handleToggleCustomizePanel }) => {
     }));
   };
 
+  // Get selected column
+  const selectedCategoryColumn = state.axisOptions.categoryOptions.find(
+    (col) => col.field === state.axisOptions.selectedCategory
+  );
+
+  const selectedXValueColumn = state.axisOptions.xValueOptions.find(
+    (col) => col.field === state.axisOptions.selectedXValue
+  );
+
+  const selectedValueColumn = state.axisOptions.valueOptions.find(
+    (col) => col.field === state.axisOptions.selectedValue
+  );
+
+  // Determine the label to show based on the column type
+  const CategoryColumnType = selectedCategoryColumn
+    ? (selectedCategoryColumn.type === "string" ? "Categorical" : "Numerical")
+    : "Unknown"; // optional fallback if no column is selecte
+
+  const xValueColumnType = selectedXValueColumn
+    ? (selectedXValueColumn.type === "string" ? "Categorical" : "Numerical")
+    : "Unknown"; // optional fallback if no column is selected
+
+  const valueColumnType = selectedValueColumn
+    ? (selectedValueColumn.type === "string" ? "Categorical" : "Numerical")
+    : "Unknown"; // optional fallback if no column is selected
+
+  const categoryLabel = `Category (${CategoryColumnType})`;
+  const xValueLabel = `X-Value (${xValueColumnType})`;
+  const valueLabel = `Value (${valueColumnType})`;
+
   return (
     <>
       <Grid container spacing={2}>
         <Grid size={{ xs: 12, md: 4 }}>
           <FormControl fullWidth>
-            <InputLabel id="category-select-label">Category</InputLabel>
+            <InputLabel id="category-select-label">{categoryLabel}</InputLabel>
             <Select
               labelId="category-select-label"
               id="category-select"
               value={state.axisOptions.selectedCategory}
               onChange={handleCategoryChange}
-              label="Category"
+              label={categoryLabel}
               variant="outlined"
             >
               {state.axisOptions.categoryOptions.map((col) => (
@@ -397,13 +427,13 @@ const TreeMap = ({ customize = false, handleToggleCustomizePanel }) => {
         </Grid>
         <Grid size={{ xs: 12, md: 4 }}>
           <FormControl fullWidth>
-            <InputLabel id="x-value-select-label">X-Value</InputLabel>
+            <InputLabel id="x-value-select-label">{xValueLabel}</InputLabel>
             <Select
               labelId="x-value-select-label"
               id="x-value-select"
               value={state.axisOptions.selectedXValue}
               onChange={handleXValueChange}
-              label="X-Value"
+              label={xValueLabel}
               variant="outlined"
             >
               {state.axisOptions.xValueOptions.map((col) => (
@@ -416,13 +446,13 @@ const TreeMap = ({ customize = false, handleToggleCustomizePanel }) => {
         </Grid>
         <Grid size={{ xs: 12, md: 4 }}>
           <FormControl fullWidth>
-            <InputLabel id="value-select-label">Value</InputLabel>
+            <InputLabel id="value-select-label">{valueLabel}</InputLabel>
             <Select
               labelId="value-select-label"
               id="value-select"
               value={state.axisOptions.selectedValue}
               onChange={handleValueChange}
-              label="Value"
+              label={valueLabel}
               variant="outlined"
             >
               {state.axisOptions.valueOptions.map((col) => (


### PR DESCRIPTION
This PR fixes the menu icon (three dots) position for number columns in the DataGrid.

It builds on top of issue #16 , improving UI consistency and column behavior.

Fixes #24 