### PR TITLE
Fixed x-axis data option based on chart type and improved UI

### DIFF
--- a/openlab/frontend/src/pages/indicator-specification-cards/creator/components/choose-path/choose-path.jsx
+++ b/openlab/frontend/src/pages/indicator-specification-cards/creator/components/choose-path/choose-path.jsx
@@ -26,12 +26,28 @@ const ChoosePath = () => {
     showSelections: true,
   });
 
+  const resetChosenPath = (path, currentMethod) => ({
+    visualization: {
+      locked: path !== "Visualization",
+      openPanel: path === "Visualization",
+      step: path === "Visualization" ? "3" : "0",
+    },
+    dataset: {
+      locked: path !== "Dataset",
+      openPanel: path === "Dataset",
+      step: path === "Dataset" ? "3" : "0",
+    },
+    method: currentMethod,
+    finalize: { locked: true, openPanel: false, step: "0" },
+  });
+
   const handleChooseVisualizationPath = () => {
     let vis = "Visualization";
     handleTogglePanel();
     if (requirements.selectedPath !== vis) {
       setLockedStep((prevState) => ({
         ...prevState,
+        ...resetChosenPath(vis, prevState.method),
         visualization: {
           ...prevState.visualization,
           locked: false,
@@ -41,7 +57,7 @@ const ChoosePath = () => {
         dataset: {
           ...prevState.dataset,
           locked: true,
-          openedPanel: false,
+          openPanel: false,
           step: "4",
         },
       }));
@@ -54,7 +70,7 @@ const ChoosePath = () => {
         ...prevState,
         visualization: {
           ...prevState.visualization,
-          openedPanel: true,
+          openPanel: true,
         },
       }));
     }
@@ -67,6 +83,7 @@ const ChoosePath = () => {
       {
         setLockedStep((prevState) => ({
           ...prevState,
+          ...resetChosenPath(data, prevState.method),
           dataset: {
             ...prevState.dataset,
             locked: false,
@@ -77,7 +94,7 @@ const ChoosePath = () => {
             ...prevState.visualization,
             locked: true,
             openPanel: false,
-            step: "4",
+            step: "5",
           },
         }));
         setRequirements((prevState) => ({
@@ -90,7 +107,7 @@ const ChoosePath = () => {
         ...prevState,
         dataset: {
           ...prevState.dataset,
-          openedPanel: true,
+          openPanel: true,
         },
       }));
     }

--- a/openlab/frontend/src/pages/indicator-specification-cards/creator/components/dataset/dataset.jsx
+++ b/openlab/frontend/src/pages/indicator-specification-cards/creator/components/dataset/dataset.jsx
@@ -20,7 +20,7 @@ import EditIcon from "@mui/icons-material/Edit";
 import CloseIcon from "@mui/icons-material/Close";
 
 const Dataset = () => {
-  const { requirements, setRequirements, lockedStep, setLockedStep,dataset } =
+  const { requirements, setRequirements, lockedStep, setLockedStep, dataset } =
     useContext(ISCContext);
   const [state, setState] = useState({
     showSelections: true,
@@ -40,14 +40,14 @@ const Dataset = () => {
         upload: {
           ...prevState.upload,
           locked: true,
-          openedPanel: false,
+          openPanel: false,
         },
         method:{
           ...prevState.method,
           type: vis,
-          locked:false,
+          locked: false,
           openPanel: true,
-          step:prevState?.dataset.step =="3"?"4":"5",
+          step: requirements.selectedPath === "Visualization" ? "5" : "4",
         }
       }));
       setRequirements((prevState) => ({
@@ -59,7 +59,7 @@ const Dataset = () => {
         ...prevState,
         manual: {
           ...prevState.manual,
-          openedPanel: true,
+          openPanel: true,
         },
       }));
     }
@@ -79,14 +79,14 @@ const Dataset = () => {
         upload: {
           ...prevState.upload,
           locked: false,
-          openedPanel: true,
+          openPanel: true,
         },
           method:{
           ...prevState.method,
           type: vis,
           locked:false,
           openPanel: true,
-          step:"5",
+          step: requirements.selectedPath === "Visualization" ? "5" : "4",
         }
       }));
       setRequirements((prevState) => ({
@@ -98,7 +98,7 @@ const Dataset = () => {
         ...prevState,
         upload: {
           ...prevState.upload,
-          openedPanel: true,
+          openPanel: true,
         },
       }));
     }
@@ -147,7 +147,7 @@ const Dataset = () => {
         disabled={lockedStep.dataset.locked}
       >
         <AccordionSummary>
-          <Grid container spacing={1}>
+          <Grid container spacing={1} direction={"column"}>
             <Grid item xs={12}>
               <Grid
                 container
@@ -233,8 +233,7 @@ const Dataset = () => {
             </Grow>
           </Grid>
         </AccordionSummary>
-
-        {(<AccordionDetails>
+        <AccordionDetails>
           <Grid container justifyContent="center" spacing={4} sx={{ py: 2 }}>
             <Grid item>
               <Paper
@@ -243,7 +242,7 @@ const Dataset = () => {
                 onClick={handleChooseManualPath}
               >
                 <Typography variant="h6" align="center">
-                  Create you own data set 
+                  Create Your Own Dataset 
                 </Typography>
               </Paper>
             </Grid>
@@ -260,8 +259,7 @@ const Dataset = () => {
               </Paper>
             </Grid>
           </Grid>
-        </AccordionDetails>)}
-
+        </AccordionDetails>
       </Accordion>
     </>
   );

--- a/openlab/frontend/src/pages/indicator-specification-cards/creator/components/finalize/components/bar-chart.jsx
+++ b/openlab/frontend/src/pages/indicator-specification-cards/creator/components/finalize/components/bar-chart.jsx
@@ -387,39 +387,18 @@ const BarChart = ({ customize = false, handleToggleCustomizePanel }) => {
     }));
   };
 
-  // Get selected column
-  const selectedXAxisColumn = state.axisOptions.xAxisOptions.find(
-    (col) => col.field === state.axisOptions.selectedXAxis
-  );
-
-  const selectedYAxisColumn = state.axisOptions.yAxisOptions.find(
-    (col) => col.field === state.axisOptions.selectedYAxis
-  );
-
-  // Determine the label to show based on the column type
-  const xAxisColumnType = selectedXAxisColumn
-    ? (selectedXAxisColumn.type === "string" ? "Categorical" : "Numerical")
-    : "No Data";
-
-  const yAxisColumnType = selectedYAxisColumn
-    ? (selectedYAxisColumn.type === "string" ? "Categorical" : "Numerical")
-    : "No Data";
-
-  const xAxisLabel = `X-Axis (${xAxisColumnType})`;
-  const yAxisLabel = `Y-Axis (${yAxisColumnType})`;
-
   return (
     <>
       <Grid container spacing={2}>
         <Grid size={{ xs: 12, md: 6 }}>
           <FormControl fullWidth>
-            <InputLabel id="x-axis-select-label">{xAxisLabel}</InputLabel>
+            <InputLabel id="x-axis-select-label">X-Axis (Categorical)</InputLabel>
             <Select
               labelId="x-axis-select-label"
               id="x-axis-select"
               value={state.axisOptions.selectedXAxis}
               onChange={handleXAxisChange}
-              label={xAxisLabel}
+              label="X-Axis (Categorical)"
               variant="outlined"
             >
               {state.axisOptions.xAxisOptions.map((col) => (
@@ -430,21 +409,21 @@ const BarChart = ({ customize = false, handleToggleCustomizePanel }) => {
             </Select>
           </FormControl>
           {/* Warning for X-Axis */}
-          {xAxisColumnType === "No Data" && (
+          {state.axisOptions.xAxisOptions.length === 0 && (
             <Typography color="error" variant="body2" sx={{ mt: 1 }}>
-              Missing categorical data
+              X-Axis requires categorical data, but none was found in your dataset.
             </Typography>
           )}
         </Grid>
         <Grid size={{ xs: 12, md: 6 }}>
           <FormControl fullWidth>
-            <InputLabel id="y-axis-select-label">{yAxisLabel}</InputLabel>
+            <InputLabel id="y-axis-select-label">Y-Axis (Numerical)</InputLabel>
             <Select
               labelId="y-axis-select-label"
               id="y-axis-select"
               value={state.axisOptions.selectedYAxis}
               onChange={handleYAxisChange}
-              label={yAxisLabel}
+              label="Y-Axis (Numerical)"
               variant="outlined"
             >
               {state.axisOptions.yAxisOptions.map((col) => (
@@ -455,9 +434,9 @@ const BarChart = ({ customize = false, handleToggleCustomizePanel }) => {
             </Select>
           </FormControl>
           {/* Warning for Y-Axis */}
-          {yAxisColumnType === "No Data" && (
+          {state.axisOptions.yAxisOptions.length === 0 && (
             <Typography color="error" variant="body2" sx={{ mt: 1 }}>
-              Missing numerical data
+              Y-Axis requires numerical data, but none was found in your dataset.
             </Typography>
           )}
         </Grid>

--- a/openlab/frontend/src/pages/indicator-specification-cards/creator/components/finalize/components/dot-chart.jsx
+++ b/openlab/frontend/src/pages/indicator-specification-cards/creator/components/finalize/components/dot-chart.jsx
@@ -172,8 +172,8 @@ const DotChart = ({ customize = false, handleToggleCustomizePanel }) => {
 
   // * This effect is used to update the chart when the dataset column changes.
   useEffect(() => {
-    const xAxisCandidates = dataset.columns.filter(
-      (col) => col.type === "string" || col.type === "catOrdered"
+    const catOrderedColumns = dataset.columns.filter(
+      (col) => col.type === "catOrdered"
     );
     const numberColumns = dataset.columns.filter(
       (col) => col.type === "number"
@@ -182,7 +182,7 @@ const DotChart = ({ customize = false, handleToggleCustomizePanel }) => {
       ...prevState,
       axisOptions: {
         ...prevState.axisOptions,
-        xAxisOptions: xAxisCandidates,
+        xAxisOptions: catOrderedColumns,
         yAxisOptions: numberColumns,
       },
     }));
@@ -192,7 +192,7 @@ const DotChart = ({ customize = false, handleToggleCustomizePanel }) => {
         ...prevVisRef.data,
         axisOptions: {
           ...prevVisRef.data.axisOptions,
-          xAxisOptions: xAxisCandidates ,
+          xAxisOptions: catOrderedColumns,
           yAxisOptions: numberColumns,
         },
       },
@@ -206,11 +206,8 @@ const DotChart = ({ customize = false, handleToggleCustomizePanel }) => {
       visRef.data.axisOptions.selectedXAxis || state.axisOptions.selectedXAxis;
     const selectedYAxis =
       visRef.data.axisOptions.selectedYAxis || state.axisOptions.selectedYAxis;
-    const stringColumns = dataset.columns.filter(
-      (col) => col.type === "string" || col.type === "catOrdered"
-    );
-    // const stringColumns =
-    //   visRef.data.axisOptions.xAxisOptions || state.axisOptions.xAxisOptions;
+    const catOrderedColumns =
+      visRef.data.axisOptions.xAxisOptions || state.axisOptions.xAxisOptions;
     const numberColumns =
       visRef.data.axisOptions.yAxisOptions || state.axisOptions.yAxisOptions;
 
@@ -219,11 +216,11 @@ const DotChart = ({ customize = false, handleToggleCustomizePanel }) => {
       updatedSelectedXAxis = selectedXAxis;
     else if (selectedXAxis.length !== 0)
       updatedSelectedXAxis =
-        stringColumns.find((col) => col.field === selectedXAxis)?.field ||
-        (stringColumns.length > 0 ? stringColumns[0].field : "");
+        catOrderedColumns.find((col) => col.field === selectedXAxis)?.field ||
+        (catOrderedColumns.length > 0 ? catOrderedColumns[0].field : "");
     else
       updatedSelectedXAxis =
-        stringColumns.length > 0 ? stringColumns[0].field : "";
+        catOrderedColumns.length > 0 ? catOrderedColumns[0].field : "";
 
     let updatedSelectedYAxis = "";
     if (visRef.edit && selectedYAxis.length !== 0)
@@ -354,54 +351,18 @@ const DotChart = ({ customize = false, handleToggleCustomizePanel }) => {
     }));
   };
 
-  // Get selected column
-  const selectedXAxisColumn = state.axisOptions.xAxisOptions.find(
-    (col) => col.field === state.axisOptions.selectedXAxis
-  );
-
-  const selectedYAxisColumn = state.axisOptions.yAxisOptions.find(
-    (col) => col.field === state.axisOptions.selectedYAxis
-  );
-
-  // Determine the label to show based on the column type
-  const getAxisTypeLabel = (type) => {
-    if (type === "string") return "Categorical";
-    if (type === "catOrdered") return "Categorical (ordinal)";
-    if (type === "number") return "Numerical";
-    return "No Data";
-  };
-
-  const xAxisColumnType = selectedXAxisColumn
-    ? getAxisTypeLabel(selectedXAxisColumn.type)
-    : "No Data";
-
-  const yAxisColumnType = selectedYAxisColumn
-    ? getAxisTypeLabel(selectedYAxisColumn.type)
-    : "No Data";
-
-  // const xAxisColumnType = selectedXAxisColumn
-  //   ? (selectedXAxisColumn.type === "string" ? "Categorical" : "Numerical")
-  //   : "No Data"; // optional fallback if no column is selecte
-
-  // const yAxisColumnType = selectedYAxisColumn
-  //   ? (selectedYAxisColumn.type === "string" ? "Categorical" : "Numerical")
-  //   : "No Data"; // optional fallback if no column is selected
-
-  const xAxisLabel = `X-Axis (${xAxisColumnType})`;
-  const yAxisLabel = `Y-Axis (${yAxisColumnType})`;
-
   return (
     <>
       <Grid container spacing={2}>
         <Grid size={{ xs: 12, md: 6 }}>
           <FormControl fullWidth>
-            <InputLabel id="x-axis-select-label">{xAxisLabel}</InputLabel>
+            <InputLabel id="x-axis-select-label">X-Axis (Ordinal)</InputLabel>
             <Select
               labelId="x-axis-select-label"
               id="x-axis-select"
               value={state.axisOptions.selectedXAxis}
               onChange={handleXAxisChange}
-              label={xAxisLabel}
+              label="X-Axis (Ordinal)"
               variant="outlined"
             >
               {state.axisOptions.xAxisOptions.map((col) => (
@@ -412,21 +373,21 @@ const DotChart = ({ customize = false, handleToggleCustomizePanel }) => {
             </Select>
           </FormControl>
           {/* Warning for X-Axis */}
-          {xAxisColumnType === "No Data" && (
+          {state.axisOptions.xAxisOptions.length === 0 && (
             <Typography color="error" variant="body2" sx={{ mt: 1 }}>
-              Missing categorical data
+              X-Axis requires ordinal data, but none was found in your dataset.
             </Typography>
           )}
         </Grid>
         <Grid size={{ xs: 12, md: 6 }}>
           <FormControl fullWidth>
-            <InputLabel id="y-axis-select-label">{yAxisLabel}</InputLabel>
+            <InputLabel id="y-axis-select-label">Y-Axis (Numerical)</InputLabel>
             <Select
               labelId="y-axis-select-label"
               id="y-axis-select"
               value={state.axisOptions.selectedYAxis}
               onChange={handleYAxisChange}
-              label={yAxisLabel}
+              label="Y-Axis (Numerical)"
               variant="outlined"
             >
               {state.axisOptions.yAxisOptions.map((col) => (
@@ -437,9 +398,9 @@ const DotChart = ({ customize = false, handleToggleCustomizePanel }) => {
             </Select>
           </FormControl>
           {/* Warning for Y-Axis */}
-          {yAxisColumnType === "No Data" && (
+          {state.axisOptions.yAxisOptions.length === 0 && (
             <Typography color="error" variant="body2" sx={{ mt: 1 }}>
-              Missing numerical data
+              Y-Axis requires numerical data, but none was found in your dataset.
             </Typography>
           )}
         </Grid>

--- a/openlab/frontend/src/pages/indicator-specification-cards/creator/components/finalize/components/grouped-bar-chart.jsx
+++ b/openlab/frontend/src/pages/indicator-specification-cards/creator/components/finalize/components/grouped-bar-chart.jsx
@@ -352,43 +352,18 @@ const GroupedBarChart = ({ customize = false, handleToggleCustomizePanel }) => {
     localStorage.removeItem("series");
   };
 
-  // Get selected column
-  const selectedXAxisColumn = state.axisOptions.xAxisOptions.find(
-    (col) => col.field === state.axisOptions.selectedXAxis
-  );
-
-  // Determine the label to show based on the column type
-  const xAxisColumnType = selectedXAxisColumn
-    ? (selectedXAxisColumn.type === "string" ? "Categorical" : "Numerical")
-    : "No Data"; // optional fallback if no column is selected
-
-  // If multiple data selected
-  const selectedYAxesColumns = (state.axisOptions.selectedYAxis || []).map((field) => {
-  const col = state.axisOptions.yAxisOptions.find((c) => c.field === field);
-    return col
-      ? col.type === "string"
-        ? "Categorical"
-        : "Numerical"
-      : "No Data";
-  });
-
-  const yAxesColumnTypes = [...new Set(selectedYAxesColumns)].join(", "); // remove duplicates
-
-  const xAxisLabel = `X-Axis (${xAxisColumnType})`;
-  const yAxesLabel = `Y-Axes (${yAxesColumnTypes})`;
-
   return (
     <>
       <Grid container spacing={2}>
         <Grid size={{ xs: 12, md: 6 }}>
           <FormControl fullWidth>
-            <InputLabel id="x-axis-select-label">{xAxisLabel}</InputLabel>
+            <InputLabel id="x-axis-select-label">X-Axis (Categorical)</InputLabel>
             <Select
               labelId="x-axis-select-label"
               id="x-axis-select"
               value={state.axisOptions.selectedXAxis}
               onChange={handleXAxisChange}
-              label={xAxisLabel}
+              label="X-Axis (Categorical)"
               variant="outlined"
             >
               {state.axisOptions.xAxisOptions.map((col) => (
@@ -399,22 +374,22 @@ const GroupedBarChart = ({ customize = false, handleToggleCustomizePanel }) => {
             </Select>
           </FormControl>
           {/* Warning for X-Axis */}
-          {xAxisColumnType === "No Data" && (
+          {state.axisOptions.xAxisOptions.length === 0 && (
             <Typography color="error" variant="body2" sx={{ mt: 1 }}>
-              Missing categorical data
+              X-Axis requires categorical data, but none was found in your dataset.
             </Typography>
           )}
         </Grid>
         <Grid size={{ xs: 12, md: 6 }}>
           <FormControl fullWidth>
-            <InputLabel id="y-axes-select-label">{yAxesLabel}</InputLabel>
+            <InputLabel id="y-axes-select-label">Y-Axes (Numerical)</InputLabel>
             <Select
               labelId="y-axes-select-label"
               id="y-axes-select"
               multiple
               value={state.axisOptions.selectedYAxis}
               onChange={handleYAxesChange}
-              label={yAxesLabel}
+              label="Y-Axes (Numerical)"
               variant="outlined"
               renderValue={(selected) =>
                 selected
@@ -436,9 +411,9 @@ const GroupedBarChart = ({ customize = false, handleToggleCustomizePanel }) => {
             <FormHelperText>Multi-select possible</FormHelperText>
           </FormControl>
           {/* Warning for Y-Axis */}
-          {selectedYAxesColumns.length === 0 && (
+          {state.axisOptions.yAxisOptions.length === 0 && (
             <Typography color="error" variant="body2" sx={{ mt: 1 }}>
-              Missing numerical data
+              Y-Axes require numerical data, but none was found in your dataset.
             </Typography>
           )}
         </Grid>

--- a/openlab/frontend/src/pages/indicator-specification-cards/creator/components/finalize/components/line-chart.jsx
+++ b/openlab/frontend/src/pages/indicator-specification-cards/creator/components/finalize/components/line-chart.jsx
@@ -187,8 +187,8 @@ const LineChart = ({ customize = false, handleToggleCustomizePanel }) => {
   }, [darkMode]);
 
   useEffect(() => {
-    const stringColumns = dataset.columns.filter(
-      (col) => col.type === "string"
+    const catOrderedColumns = dataset.columns.filter(
+      (col) => col.type === "catOrdered"
     );
     const numberColumns = dataset.columns.filter(
       (col) => col.type === "number"
@@ -197,7 +197,7 @@ const LineChart = ({ customize = false, handleToggleCustomizePanel }) => {
       ...prevState,
       axisOptions: {
         ...prevState.axisOptions,
-        xAxisOptions: stringColumns,
+        xAxisOptions: catOrderedColumns,
         yAxisOptions: numberColumns,
       },
     }));
@@ -207,7 +207,7 @@ const LineChart = ({ customize = false, handleToggleCustomizePanel }) => {
         ...prevVisRef.data,
         axisOptions: {
           ...prevVisRef.data.axisOptions,
-          xAxisOptions: stringColumns,
+          xAxisOptions: catOrderedColumns,
           yAxisOptions: numberColumns,
         },
       },
@@ -220,7 +220,7 @@ const LineChart = ({ customize = false, handleToggleCustomizePanel }) => {
       visRef.data.axisOptions.selectedXAxis || state.axisOptions.selectedXAxis;
     const selectedYAxis =
       visRef.data.axisOptions.selectedYAxis || state.axisOptions.selectedYAxis;
-    const stringColumns =
+    const catOrderedColumns =
       visRef.data.axisOptions.xAxisOptions || state.axisOptions.xAxisOptions;
     const numberColumns =
       visRef.data.axisOptions.yAxisOptions || state.axisOptions.yAxisOptions;
@@ -230,11 +230,11 @@ const LineChart = ({ customize = false, handleToggleCustomizePanel }) => {
       updatedSelectedXAxis = selectedXAxis;
     else if (selectedXAxis.length !== 0)
       updatedSelectedXAxis =
-        stringColumns.find((col) => col.field === selectedXAxis)?.field ||
-        (stringColumns.length > 0 ? stringColumns[0].field : "");
+        catOrderedColumns.find((col) => col.field === selectedXAxis)?.field ||
+        (catOrderedColumns.length > 0 ? catOrderedColumns[0].field : "");
     else
       updatedSelectedXAxis =
-        stringColumns.length > 0 ? stringColumns[0].field : "";
+        catOrderedColumns.length > 0 ? catOrderedColumns[0].field : "";
 
     let updatedSelectedYAxis = [];
     if (visRef.edit && selectedYAxis.length !== 0)
@@ -352,43 +352,18 @@ const LineChart = ({ customize = false, handleToggleCustomizePanel }) => {
     localStorage.removeItem("series");
   };
 
-  // Get selected column
-  const selectedXAxisColumn = state.axisOptions.xAxisOptions.find(
-    (col) => col.field === state.axisOptions.selectedXAxis
-  );
-
-  // Determine the label to show based on the column type
-  const xAxisColumnType = selectedXAxisColumn
-    ? (selectedXAxisColumn.type === "string" ? "Categorical" : "Numerical")
-    : "No Data"; // optional fallback if no column is selected
-
-  // If multiple data selected
-  const selectedYAxesColumns = (state.axisOptions.selectedYAxis || []).map((field) => {
-  const col = state.axisOptions.yAxisOptions.find((c) => c.field === field);
-    return col
-    ? col.type === "string"
-        ? "Categorical"
-        : "Numerical"
-      : "No Data"
-  });
-
-  const yAxesColumnTypes = [...new Set(selectedYAxesColumns)].join(", "); // remove duplicates
-
-  const xAxisLabel = `X-Axis (${xAxisColumnType})`;
-  const yAxesLabel = `Y-Axes (${yAxesColumnTypes})`;
-
   return (
     <>
       <Grid container spacing={2}>
         <Grid size={{ xs: 12, md: 6 }}>
           <FormControl fullWidth>
-            <InputLabel id="x-axis-select-label">{xAxisLabel}</InputLabel>
+            <InputLabel id="x-axis-select-label">X-Axis (Ordinal)</InputLabel>
             <Select
               labelId="x-axis-select-label"
               id="x-axis-select"
               value={state.axisOptions.selectedXAxis}
               onChange={handleXAxisChange}
-              label={xAxisLabel}
+              label="X-Axis (Ordinal)"
               variant="outlined"
             >
               {state.axisOptions.xAxisOptions.map((col) => (
@@ -399,22 +374,22 @@ const LineChart = ({ customize = false, handleToggleCustomizePanel }) => {
             </Select>
           </FormControl>
           {/* Warning for X-Axis */}
-            {xAxisColumnType === "No Data" && (
+            {state.axisOptions.xAxisOptions.length === 0 && (
               <Typography color="error" variant="body2" sx={{ mt: 1 }}>
-                Missing categorical data
+                X-Axis requires ordinal data, but none was found in your dataset.
               </Typography>
             )}
         </Grid>
         <Grid size={{ xs: 12, md: 6 }}>
           <FormControl fullWidth>
-            <InputLabel id="y-axes-select-label">{yAxesLabel}</InputLabel>
+            <InputLabel id="y-axes-select-label">Y-Axes (Numerical)</InputLabel>
             <Select
               labelId="y-axes-select-label"
               id="y-axes-select"
               multiple
               value={state.axisOptions.selectedYAxis}
               onChange={handleYAxesChange}
-              label={yAxesLabel}
+              label="Y-Axis (Numerical)"
               variant="outlined"
               renderValue={(selected) =>
                 selected
@@ -436,9 +411,9 @@ const LineChart = ({ customize = false, handleToggleCustomizePanel }) => {
             <FormHelperText>Multi-select possible</FormHelperText>
           </FormControl>
           {/* Warning for Y-Axis */}
-            {selectedYAxesColumns.length === 0 && (
+            {state.axisOptions.yAxisOptions.length === 0 && (
               <Typography color="error" variant="body2" sx={{ mt: 1 }}>
-                Missing numerical data
+                Y-Axes require numerical data, but none was found in your dataset.
               </Typography>
           )}
         </Grid>

--- a/openlab/frontend/src/pages/indicator-specification-cards/creator/components/finalize/components/pie-chart.jsx
+++ b/openlab/frontend/src/pages/indicator-specification-cards/creator/components/finalize/components/pie-chart.jsx
@@ -331,39 +331,18 @@ const PieChart = ({ customize = false, handleToggleCustomizePanel }) => {
     }));
   };
 
-// Get selected column
-  const selectedXAxisColumn = state.axisOptions.xAxisOptions.find(
-    (col) => col.field === state.axisOptions.selectedXAxis
-  );
-
-  const selectedYAxisColumn = state.axisOptions.yAxisOptions.find(
-    (col) => col.field === state.axisOptions.selectedYAxis
-  );
-
-  // Determine the label to show based on the column type
-  const xAxisColumnType = selectedXAxisColumn
-    ? (selectedXAxisColumn.type === "string" ? "Categorical" : "Numerical")
-    : "No Data"; // optional fallback if no column is selecte
-
-  const yAxisColumnType = selectedYAxisColumn
-    ? (selectedYAxisColumn.type === "string" ? "Categorical" : "Numerical")
-    : "No Data"; // optional fallback if no column is selected
-
-  const xAxisLabel = `Categories (${xAxisColumnType})`;
-  const yAxisLabel = `Values (${yAxisColumnType})`;
-
   return (
     <>
       <Grid container spacing={2}>
         <Grid size={{ xs: 12, md: 6 }}>
           <FormControl fullWidth>
-            <InputLabel id="x-axis-select-label">{xAxisLabel}</InputLabel>
+            <InputLabel id="x-axis-select-label">Categories (Categorical)</InputLabel>
             <Select
               labelId="x-axis-select-label"
               id="x-axis-select"
               value={state.axisOptions.selectedXAxis}
               onChange={handleXAxisChange}
-              label={xAxisLabel}
+              label="Categories (Categorical)"
               variant="outlined"
             >
               {state.axisOptions.xAxisOptions.map((col) => (
@@ -374,21 +353,21 @@ const PieChart = ({ customize = false, handleToggleCustomizePanel }) => {
             </Select>
           </FormControl>
           {/* Warning for X-Axis */}
-          {xAxisColumnType === "No Data" && (
+          {state.axisOptions.xAxisOptions.length === 0 && (
             <Typography color="error" variant="body2" sx={{ mt: 1 }}>
-              Missing categorical data
+              Categories requires categorical data, but none was found in your dataset.
             </Typography>
           )}
         </Grid>
         <Grid size={{ xs: 12, md: 6 }}>
           <FormControl fullWidth>
-            <InputLabel id="y-axis-select-label">{yAxisLabel}</InputLabel>
+            <InputLabel id="y-axis-select-label">Values (Numerical)</InputLabel>
             <Select
               labelId="y-axis-select-label"
               id="y-axis-select"
               value={state.axisOptions.selectedYAxis}
               onChange={handleYAxisChange}
-              label={yAxisLabel}
+              label="Values (Numerical)"
               variant="outlined"
             >
               {state.axisOptions.yAxisOptions.map((col) => (
@@ -399,9 +378,9 @@ const PieChart = ({ customize = false, handleToggleCustomizePanel }) => {
             </Select>
           </FormControl>
           {/* Warning for Y-Axis */}
-          {yAxisColumnType === "No Data" && (
+          {state.axisOptions.yAxisOptions.length === 0 && (
             <Typography color="error" variant="body2" sx={{ mt: 1 }}>
-              Missing numerical data
+              Values requires numerical data, but none was found in your dataset.
              </Typography>
           )}
         </Grid>

--- a/openlab/frontend/src/pages/indicator-specification-cards/creator/components/finalize/components/polar-area-chart.jsx
+++ b/openlab/frontend/src/pages/indicator-specification-cards/creator/components/finalize/components/polar-area-chart.jsx
@@ -331,39 +331,18 @@ const PolarAreaChart = ({ customize = false, handleToggleCustomizePanel }) => {
     }));
   };
 
-  // Get selected column
-  const selectedXAxisColumn = state.axisOptions.xAxisOptions.find(
-    (col) => col.field === state.axisOptions.selectedXAxis
-  );
-
-  const selectedYAxisColumn = state.axisOptions.yAxisOptions.find(
-    (col) => col.field === state.axisOptions.selectedYAxis
-  );
-
-  // Determine the label to show based on the column type
-  const xAxisColumnType = selectedXAxisColumn
-    ? (selectedXAxisColumn.type === "string" ? "Categorical" : "Numerical")
-    : "No Data";
-
-  const yAxisColumnType = selectedYAxisColumn
-    ? (selectedYAxisColumn.type === "string" ? "Categorical" : "Numerical")
-    : "No Data";
-
-  const xAxisLabel = `Categories (${xAxisColumnType})`;
-  const yAxisLabel = `Values (${yAxisColumnType})`;
-
   return (
     <>
       <Grid container spacing={2}>
         <Grid size={{ xs: 12, md: 6 }}>
           <FormControl fullWidth>
-            <InputLabel id="x-axis-select-label">{xAxisLabel}</InputLabel>
+            <InputLabel id="x-axis-select-label">Categories (Categorical)</InputLabel>
             <Select
               labelId="x-axis-select-label"
               id="x-axis-select"
               value={state.axisOptions.selectedXAxis}
               onChange={handleXAxisChange}
-              label={xAxisLabel}
+              label="Categories (Categorical)"
               variant="outlined"
             >
               {state.axisOptions.xAxisOptions.map((col) => (
@@ -374,21 +353,21 @@ const PolarAreaChart = ({ customize = false, handleToggleCustomizePanel }) => {
             </Select>
           </FormControl>
           {/* Warning for X-Axis */}
-          {xAxisColumnType === "No Data" && (
+          {state.axisOptions.xAxisOptions.length === 0 && (
             <Typography color="error" variant="body2" sx={{ mt: 1 }}>
-              Missing categorical data
+              Categories requires categorical data, but none was found in your dataset.
             </Typography>
           )}
         </Grid>
         <Grid size={{ xs: 12, md: 6 }}>
           <FormControl fullWidth>
-            <InputLabel id="y-axis-select-label">{yAxisLabel}</InputLabel>
+            <InputLabel id="y-axis-select-label">Values (Numerical)</InputLabel>
             <Select
               labelId="y-axis-select-label"
               id="y-axis-select"
               value={state.axisOptions.selectedYAxis}
               onChange={handleYAxisChange}
-              label={yAxisLabel}
+              label="Values (Numerical)"
               variant="outlined"
             >
               {state.axisOptions.yAxisOptions.map((col) => (
@@ -399,9 +378,9 @@ const PolarAreaChart = ({ customize = false, handleToggleCustomizePanel }) => {
             </Select>
           </FormControl>
           {/* Warning for Y-Axis */}
-          {yAxisColumnType === "No Data" && (
+          {state.axisOptions.yAxisOptions.length === 0 && (
             <Typography color="error" variant="body2" sx={{ mt: 1 }}>
-              Missing numerical data
+              Values requires numerical data, but none was found in your dataset.
             </Typography>
           )}
         </Grid>

--- a/openlab/frontend/src/pages/indicator-specification-cards/creator/components/finalize/components/radar-chart.jsx
+++ b/openlab/frontend/src/pages/indicator-specification-cards/creator/components/finalize/components/radar-chart.jsx
@@ -351,43 +351,18 @@ const RadarChart = ({ customize = false, handleToggleCustomizePanel }) => {
     }));
   };
 
-  // Get selected column
-  const selectedXAxisColumn = state.axisOptions.xAxisOptions.find(
-    (col) => col.field === state.axisOptions.selectedXAxis
-  );
-
-  // Determine the label to show based on the column type
-  const xAxisColumnType = selectedXAxisColumn
-    ? (selectedXAxisColumn.type === "string" ? "Categorical" : "Numerical")
-    : "No Data";
-
-  // If multiple data selected
-  const selectedYAxesColumns = (state.axisOptions.selectedYAxis || []).map((field) => {
-  const col = state.axisOptions.yAxisOptions.find((c) => c.field === field);
-    return col
-    ? col.type === "string"
-      ? "Categorical"
-      : "Numerical"
-    : "No Data";
-  });
-
-  const yAxesColumnTypes = [...new Set(selectedYAxesColumns)].join(", "); // remove duplicates
-
-  const xAxisLabel = `X-Axis (${xAxisColumnType})`;
-  const yAxisLabel = `Y-Axes (${yAxesColumnTypes})`;
-
   return (
     <>
       <Grid container spacing={2}>
         <Grid size={{ xs: 12, md: 6 }}>
           <FormControl fullWidth>
-            <InputLabel id="x-axis-select-label">{xAxisLabel}</InputLabel>
+            <InputLabel id="x-axis-select-label">X-Axis (Categorical)</InputLabel>
             <Select
               labelId="x-axis-select-label"
               id="x-axis-select"
               value={state.axisOptions.selectedXAxis}
               onChange={handleXAxisChange}
-              label={xAxisLabel}
+              label="X-Axis (Categorical)"
               variant="outlined"
             >
               {state.axisOptions.xAxisOptions.map((col) => (
@@ -398,22 +373,22 @@ const RadarChart = ({ customize = false, handleToggleCustomizePanel }) => {
             </Select>
           </FormControl>
           {/* Warning for X-Axis */}
-            {xAxisColumnType === "No Data" && (
+            {state.axisOptions.xAxisOptions.length === 0 && (
               <Typography color="error" variant="body2" sx={{ mt: 1 }}>
-                Missing categorical data
+                X-Axis requires categorical data, but none was found in your dataset.
               </Typography>
           )}
         </Grid>
         <Grid size={{ xs: 12, md: 6 }}>
           <FormControl fullWidth>
-            <InputLabel id="y-axis-select-label">{yAxisLabel}</InputLabel>
+            <InputLabel id="y-axis-select-label">Y-Axes (Numerical)</InputLabel>
             <Select
               labelId="y-axis-select-label"
               id="y-axis-select"
               multiple
               value={state.axisOptions.selectedYAxis}
               onChange={handleYAxisChange}
-              label={yAxisLabel}
+              label="Y-Axes (Numerical)"
               variant="outlined"
               renderValue={(selected) =>
                 selected
@@ -435,9 +410,9 @@ const RadarChart = ({ customize = false, handleToggleCustomizePanel }) => {
             <FormHelperText>Multi-select possible</FormHelperText>
           </FormControl>
           {/* Warning for Y-Axis */}
-          {selectedYAxesColumns.length === 0 && (
+          {state.axisOptions.yAxisOptions.length === 0 && (
             <Typography color="error" variant="body2" sx={{ mt: 1 }}>
-              Missing numerical data
+              Y-Axes require numerical data, but none was found in your dataset.
             </Typography>
           )}
         </Grid>

--- a/openlab/frontend/src/pages/indicator-specification-cards/creator/components/finalize/components/scatter-plot-chart.jsx
+++ b/openlab/frontend/src/pages/indicator-specification-cards/creator/components/finalize/components/scatter-plot-chart.jsx
@@ -418,48 +418,18 @@ const ScatterPlotChart = ({
     }));
   };
 
-  // Get selected column
-  const selectedXAxisColumn = state.axisOptions.xAxisOptions.find(
-    (col) => col.field === state.axisOptions.selectedXAxis
-  );
-
-  const selectedYAxisColumn = state.axisOptions.yAxisOptions.find(
-    (col) => col.field === state.axisOptions.selectedYAxis
-  );
-
-  const selectedLabelColumn = state.axisOptions.labelOptions.find(
-    (col) => col.field === state.axisOptions.selectedLabel
-  );
-
-  // Determine the label to show based on the column type
-  const xAxisColumnType = selectedXAxisColumn
-    ? (selectedXAxisColumn.type === "string" ? "Categorical" : "Numerical")
-    : "No Data"; // optional fallback if no column is selecte
-
-  const yAxisColumnType = selectedYAxisColumn
-    ? (selectedYAxisColumn.type === "string" ? "Categorical" : "Numerical")
-    : "No Data"; // optional fallback if no column is selected
-
-  const labelColumnType = selectedLabelColumn
-    ? (selectedLabelColumn.type === "string" ? "Categorical" : "Numerical")
-    : "No Data"; // optional fallback if no column is selected
-
-  const xAxisLabel = `X-Axis (${xAxisColumnType})`;
-  const yAxisLabel = `Y-Axis (${yAxisColumnType})`;
-  const labels = `Labels (${labelColumnType})`;
-
   return (
     <>
       <Grid container spacing={2}>
         <Grid size={{ xs: 12, md: 4 }}>
           <FormControl fullWidth>
-            <InputLabel id="x-axis-select-label">{xAxisLabel}</InputLabel>
+            <InputLabel id="x-axis-select-label">X-Axis (Numerical)</InputLabel>
             <Select
               labelId="x-axis-select-label"
               id="x-axis-select"
               value={state.axisOptions.selectedXAxis}
               onChange={handleXAxisChange}
-              label={xAxisLabel}
+              label="X-Axis (Numerical)"
               variant="outlined"
             >
               {state.axisOptions.xAxisOptions.map((col) => (
@@ -470,21 +440,27 @@ const ScatterPlotChart = ({
             </Select>
           </FormControl>
           {/* Warning for X-Axis */}
-          {xAxisColumnType === "No Data" && (
+          {state.axisOptions.xAxisOptions.length === 0 && (
             <Typography color="error" variant="body2" sx={{ mt: 1 }}>
-              Missing numerical data
+              No numerical data found in your dataset.
+            </Typography>
+          )}
+          {/* Warning for X-Axis and Y-Axis conflict */}
+          {state.axisOptions.selectedXAxis === state.axisOptions.selectedYAxis && (
+            <Typography color="error" variant="body2" sx={{ mt: 1 }}>
+              X-Axis and Y-Axis cannot be the same.
             </Typography>
           )}
         </Grid>
         <Grid size={{ xs: 12, md: 4 }}>
           <FormControl fullWidth>
-            <InputLabel id="y-axis-select-label">{yAxisLabel}</InputLabel>
+            <InputLabel id="y-axis-select-label">Y-Axis (Numerical)</InputLabel>
             <Select
               labelId="y-axis-select-label"
               id="y-axis-select"
               value={state.axisOptions.selectedYAxis}
               onChange={handleYAxisChange}
-              label={yAxisLabel}
+              label="Y-Axis (Numerical)"
               variant="outlined"
             >
               {state.axisOptions.yAxisOptions.map((col) => (
@@ -495,21 +471,21 @@ const ScatterPlotChart = ({
             </Select>
           </FormControl>
           {/* Warning for Y-Axis */}
-          {yAxisColumnType === "No Data" && (
+          {state.axisOptions.yAxisOptions.length === 0 && (
             <Typography color="error" variant="body2" sx={{ mt: 1 }}>
-              Missing numerical data
+              No numerical data found in your dataset.
             </Typography>
           )}
         </Grid>
         <Grid size={{ xs: 12, md: 4 }}>
           <FormControl fullWidth>
-            <InputLabel id="label-select-label">{labels}</InputLabel>
+            <InputLabel id="label-select-label">Labels (Categorical)</InputLabel>
             <Select
               labelId="label-select-label"
               id="label-select"
               value={state.axisOptions.selectedLabel}
               onChange={handleLabelChange}
-              label={labels}
+              label="Labels (Categorical)"
               variant="outlined"
             >
               {state.axisOptions.labelOptions.map((col) => (
@@ -520,9 +496,9 @@ const ScatterPlotChart = ({
             </Select>
           </FormControl>
           {/* Warning for Labels */}
-          {labelColumnType === "No Data" && (
+          {state.axisOptions.labelOptions.length === 0 && (
             <Typography color="error" variant="body2" sx={{ mt: 1 }}>
-              Missing categorical data
+              No categorical data found in your dataset.
             </Typography>
           )}
         </Grid>

--- a/openlab/frontend/src/pages/indicator-specification-cards/creator/components/finalize/components/scatter-plot-chart.jsx
+++ b/openlab/frontend/src/pages/indicator-specification-cards/creator/components/finalize/components/scatter-plot-chart.jsx
@@ -446,7 +446,9 @@ const ScatterPlotChart = ({
             </Typography>
           )}
           {/* Warning for X-Axis and Y-Axis conflict */}
-          {state.axisOptions.selectedXAxis === state.axisOptions.selectedYAxis && (
+          {state.axisOptions.selectedXAxis &&
+            state.axisOptions.selectedYAxis &&
+            state.axisOptions.selectedXAxis === state.axisOptions.selectedYAxis && (
             <Typography color="error" variant="body2" sx={{ mt: 1 }}>
               X-Axis and Y-Axis cannot be the same.
             </Typography>

--- a/openlab/frontend/src/pages/indicator-specification-cards/creator/components/finalize/components/stacked-bar-chart.jsx
+++ b/openlab/frontend/src/pages/indicator-specification-cards/creator/components/finalize/components/stacked-bar-chart.jsx
@@ -589,48 +589,18 @@ const StackedBarChart = ({ customize = false, handleToggleCustomizePanel }) => {
     }));
   }, []);
 
-  // Get selected column
-  const selectedXAxisColumn = state.axisOptions.xAxisOptions.find(
-    (col) => col.field === state.axisOptions.selectedXAxis
-  );
-
-  const selectedYAxisColumn = state.axisOptions.yAxisOptions.find(
-    (col) => col.field === state.axisOptions.selectedYAxis
-  );
-
-  const selectedStackColumn = state.axisOptions.barValueOptions.find(
-    (col) => col.field === state.axisOptions.selectedBarValue
-  );
-
-  // Determine the label to show based on the column type
-  const xAxisColumnType = selectedXAxisColumn
-    ? (selectedXAxisColumn.type === "string" ? "Categorical" : "Numerical")
-    : "No Data"; // optional fallback if no column is selecte
-
-  const yAxisColumnType = selectedYAxisColumn
-    ? (selectedYAxisColumn.type === "string" ? "Categorical" : "Numerical")
-    : "No Data"; // optional fallback if no column is selected
-
-  const stackColumnType = selectedStackColumn
-    ? (selectedStackColumn.type === "string" ? "Categorical" : "Numerical")
-    : "No Data"; // optional fallback if no column is selected
-
-  const xAxisLabel = `X-Axis: Group By (${xAxisColumnType})`;
-  const yAxisLabel = `Y-Axis (${yAxisColumnType})`;
-  const stackLabel = `Stack Label (${stackColumnType})`;
-
   return (
     <>
       <Grid container spacing={2}>
         <Grid size={{ xs: 12, md: 4 }}>
           <FormControl fullWidth>
-            <InputLabel id="x-axis-select-label">{xAxisLabel}</InputLabel>
+            <InputLabel id="x-axis-select-label">X-Axis: Group By (Categorical)</InputLabel>
             <Select
               labelId="x-axis-select-label"
               id="x-axis-select"
               value={state.axisOptions.selectedXAxis}
               onChange={handleXAxisChange}
-              label={xAxisLabel}
+              label="X-Axis: Group By (Categorical)"
               variant="outlined"
             >
               {state.axisOptions.xAxisOptions.map((col) => (
@@ -641,21 +611,29 @@ const StackedBarChart = ({ customize = false, handleToggleCustomizePanel }) => {
             </Select>
           </FormControl>
           {/* Warning for X-Axis */}
-          {xAxisColumnType === "No Data" && (
+          {state.axisOptions.xAxisOptions.length === 0 && (
             <Typography color="error" variant="body2" sx={{ mt: 1 }}>
-              Missing categorical data
+              No categorical data found in your dataset.
+            </Typography>
+          )}
+          {/* Warning for X-Axis and Stack Label conflict */}
+          {state.axisOptions.selectedXAxis &&
+            state.axisOptions.selectedBarValue &&
+            state.axisOptions.selectedXAxis === state.axisOptions.selectedBarValue && (
+            <Typography color="error" variant="body2" sx={{ mt: 1 }}>
+              X-Axis and Stack Label cannot be the same.
             </Typography>
           )}
         </Grid>
         <Grid size={{ xs: 12, md: 4 }}>
           <FormControl fullWidth>
-            <InputLabel id="bar-value-select-label">{stackLabel}</InputLabel>
+            <InputLabel id="bar-value-select-label">Stack Label (Categorical)</InputLabel>
             <Select
               labelId="bar-value-select-label"
               id="bar-value-select"
               value={state.axisOptions.selectedBarValue}
               onChange={handleBarValueChange}
-              label={stackLabel}
+              label="Stack Label (Categorical)"
               variant="outlined"
             >
               {state.axisOptions.barValueOptions.map((col) => (
@@ -665,22 +643,22 @@ const StackedBarChart = ({ customize = false, handleToggleCustomizePanel }) => {
               ))}
             </Select>
           </FormControl>
-          {/* Warning for stackColumnType */}
-          {stackColumnType === "No Data" && (
+          {/* Warning for Stack Label */}
+          {state.axisOptions.barValueOptions.length === 0 && (
             <Typography color="error" variant="body2" sx={{ mt: 1 }}>
-              Missing categorical data
+              No categorical data found in your dataset.
             </Typography>
           )}
         </Grid>
         <Grid size={{ xs: 12, md: 4 }}>
           <FormControl fullWidth>
-            <InputLabel id="y-axis-select-label">{yAxisLabel}</InputLabel>
+            <InputLabel id="y-axis-select-label">Y-Axis (Numerical)</InputLabel>
             <Select
               labelId="y-axis-select-label"
               id="y-axis-select"
               value={state.axisOptions.selectedYAxis}
               onChange={handleYAxisChange}
-              label={yAxisLabel}
+              label="Y-Axis (Numerical)"
               variant="outlined"
             >
               {state.axisOptions.yAxisOptions.map((col) => (
@@ -691,9 +669,9 @@ const StackedBarChart = ({ customize = false, handleToggleCustomizePanel }) => {
             </Select>
           </FormControl>
           {/* Warning for Y-Axis */}
-          {yAxisColumnType === "No Data" && (
+          {state.axisOptions.yAxisOptions.length === 0 && (
             <Typography color="error" variant="body2" sx={{ mt: 1 }}>
-              Missing numerical data
+              No numerical data found in your dataset.
             </Typography>
           )}
         </Grid>

--- a/openlab/frontend/src/pages/indicator-specification-cards/creator/components/finalize/components/treemap.jsx
+++ b/openlab/frontend/src/pages/indicator-specification-cards/creator/components/finalize/components/treemap.jsx
@@ -373,48 +373,18 @@ const TreeMap = ({ customize = false, handleToggleCustomizePanel }) => {
     }));
   };
 
-  // Get selected column
-  const selectedCategoryColumn = state.axisOptions.categoryOptions.find(
-    (col) => col.field === state.axisOptions.selectedCategory
-  );
-
-  const selectedXValueColumn = state.axisOptions.xValueOptions.find(
-    (col) => col.field === state.axisOptions.selectedXValue
-  );
-
-  const selectedValueColumn = state.axisOptions.valueOptions.find(
-    (col) => col.field === state.axisOptions.selectedValue
-  );
-
-  // Determine the label to show based on the column type
-  const categoryColumnType = selectedCategoryColumn
-    ? (selectedCategoryColumn.type === "string" ? "Categorical" : "Numerical")
-    : "No Data"; // optional fallback if no column is selecte
-
-  const xValueColumnType = selectedXValueColumn
-    ? (selectedXValueColumn.type === "string" ? "Categorical" : "Numerical")
-    : "No Data"; // optional fallback if no column is selected
-
-  const valueColumnType = selectedValueColumn
-    ? (selectedValueColumn.type === "string" ? "Categorical" : "Numerical")
-    : "No Data"; // optional fallback if no column is selected
-
-  const categoryLabel = `Category (${categoryColumnType})`;
-  const xValueLabel = `X-Value (${xValueColumnType})`;
-  const valueLabel = `Value (${valueColumnType})`;
-
   return (
     <>
       <Grid container spacing={2}>
         <Grid size={{ xs: 12, md: 4 }}>
           <FormControl fullWidth>
-            <InputLabel id="category-select-label">{categoryLabel}</InputLabel>
+            <InputLabel id="category-select-label">Category (Categorical)</InputLabel>
             <Select
               labelId="category-select-label"
               id="category-select"
               value={state.axisOptions.selectedCategory}
               onChange={handleCategoryChange}
-              label={categoryLabel}
+              label="Category (Categorical)"
               variant="outlined"
             >
               {state.axisOptions.categoryOptions.map((col) => (
@@ -425,21 +395,29 @@ const TreeMap = ({ customize = false, handleToggleCustomizePanel }) => {
             </Select>
           </FormControl>
           {/* Warning for Category */}
-          {categoryColumnType === "No Data" && (
+          {state.axisOptions.categoryOptions.length === 0 && (
             <Typography color="error" variant="body2" sx={{ mt: 1 }}>
-              Missing categorical data
+              No categorical data found in your dataset.
+            </Typography>
+          )}
+          {/* Warning for Category and X-Value conflict*/}
+          {state.axisOptions.selectedCategory &&
+            state.axisOptions.selectedXValue &&
+            state.axisOptions.selectedCategory === state.axisOptions.selectedXValue && (
+            <Typography color="error" variant="body2" sx={{ mt: 1 }}>
+              Category and X-Value cannot be the same.
             </Typography>
           )}
         </Grid>
         <Grid size={{ xs: 12, md: 4 }}>
           <FormControl fullWidth>
-            <InputLabel id="x-value-select-label">{xValueLabel}</InputLabel>
+            <InputLabel id="x-value-select-label">X-Value (Categorical)</InputLabel>
             <Select
               labelId="x-value-select-label"
               id="x-value-select"
               value={state.axisOptions.selectedXValue}
               onChange={handleXValueChange}
-              label={xValueLabel}
+              label="X-Value (Categorical)"
               variant="outlined"
             >
               {state.axisOptions.xValueOptions.map((col) => (
@@ -450,21 +428,21 @@ const TreeMap = ({ customize = false, handleToggleCustomizePanel }) => {
             </Select>
           </FormControl>
           {/* Warning for X-Value */}
-          {xValueColumnType === "No Data" && (
+          {state.axisOptions.xValueOptions.length === 0 && (
             <Typography color="error" variant="body2" sx={{ mt: 1 }}>
-              Missing categorical data
+              No categorical data found in your dataset.
             </Typography>
           )}
         </Grid>
         <Grid size={{ xs: 12, md: 4 }}>
           <FormControl fullWidth>
-            <InputLabel id="value-select-label">{valueLabel}</InputLabel>
+            <InputLabel id="value-select-label">Value (Numerical)</InputLabel>
             <Select
               labelId="value-select-label"
               id="value-select"
               value={state.axisOptions.selectedValue}
               onChange={handleValueChange}
-              label={valueLabel}
+              label="Value (Numerical)"
               variant="outlined"
             >
               {state.axisOptions.valueOptions.map((col) => (
@@ -475,9 +453,9 @@ const TreeMap = ({ customize = false, handleToggleCustomizePanel }) => {
             </Select>
           </FormControl>
           {/* Warning for Value */}
-          {valueColumnType === "No Data" && (
+          {state.axisOptions.valueOptions.length === 0 && (
             <Typography color="error" variant="body2" sx={{ mt: 1 }}>
-              Missing numerical data
+              No numerical data found in your dataset.
             </Typography>
           )}
         </Grid>

--- a/openlab/frontend/src/pages/indicator-specification-cards/creator/components/method/method.jsx
+++ b/openlab/frontend/src/pages/indicator-specification-cards/creator/components/method/method.jsx
@@ -22,7 +22,7 @@ import ImportDialog from "../dataset/components/import-dialog.jsx";
 import DataTable from "../dataset/components/data-table.jsx"
 
 const Method = () =>{
-  const { requirements, lockedStep, setLockedStep,dataset ,setDataset} =
+  const { requirements, lockedStep, setLockedStep, dataset, setDataset } =
     useContext(ISCContext);
   const [state, setState] = useState({
     showSelections: true,
@@ -83,6 +83,7 @@ const Method = () =>{
         ...prevState.finalize,
         locked: false,
         openPanel: true,
+        step: "6",
       },
     }));
   };
@@ -94,7 +95,7 @@ const Method = () =>{
         disabled={lockedStep.method.locked}
       >
         <AccordionSummary>
-          <Grid container spacing={1}>
+          <Grid container spacing={1} direction={"column"}>
             <Grid item xs={12}>
               <Grid
                 container

--- a/openlab/frontend/src/pages/indicator-specification-cards/creator/components/specify-requirements/specify-requirements.jsx
+++ b/openlab/frontend/src/pages/indicator-specification-cards/creator/components/specify-requirements/specify-requirements.jsx
@@ -25,6 +25,7 @@ import EditIcon from "@mui/icons-material/Edit";
 import CloseIcon from "@mui/icons-material/Close";
 import DoneIcon from "@mui/icons-material/Done";
 import Dialog from '@mui/material/Dialog';
+import DialogTitle from "@mui/material/DialogTitle";
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
@@ -51,7 +52,6 @@ const SpecifyRequirements = () => {
       setPermissionToChange(false);
     }
   },[permissionToChange])
-  const navigate = useNavigate(); // <--- Zurück zur Dashboard-Navigation
 
   // pop up prompt after user stops typing for a while
   React.useEffect(() => {
@@ -671,13 +671,18 @@ const SpecifyRequirements = () => {
             aria-labelledby="alert-dialog-title"
             aria-describedby="alert-dialog-description"
           >
+            <DialogTitle id="alert-dialog-title">
+              Confirm Changes
+            </DialogTitle>
             <DialogContent>
-              <DialogContentText id="alert-dialog-description">Do you want to update the changes in the following steps</DialogContentText>
+              <DialogContentText id="alert-dialog-description">
+                Do you want to apply these changes to the following steps?
+              </DialogContentText>
             </DialogContent>
             <DialogActions>
-              <Button onClick={handleDeclineChange}>Disagree</Button>
-              <Button onClick={handleConfirmChange} autoFocus>
-                Agree
+              <Button onClick={handleDeclineChange}>Cancel</Button>
+              <Button onClick={handleConfirmChange} color="primary" variant="contained" autoFocus>
+                Confirm
               </Button>
             </DialogActions>
           </Dialog>

--- a/openlab/frontend/src/pages/indicator-specification-cards/creator/components/visualization/visualization.jsx
+++ b/openlab/frontend/src/pages/indicator-specification-cards/creator/components/visualization/visualization.jsx
@@ -27,7 +27,6 @@ const Visualization = () => {
     lockedStep,
     setLockedStep,
     visRef,
-    chartIsValid,
   } = useContext(ISCContext);
   const [state, setState] = useState({
     showSelections: true,
@@ -71,6 +70,7 @@ const Visualization = () => {
         ...prevState.finalize,
         locked: false,
         openPanel: true,
+        step: "6",
       },
     }));
   };

--- a/openlab/frontend/src/pages/indicator-specification-cards/creator/indicator-specification-card.jsx
+++ b/openlab/frontend/src/pages/indicator-specification-cards/creator/indicator-specification-card.jsx
@@ -12,8 +12,8 @@ import Dialog from "@mui/material/Dialog";
 import DialogTitle from "@mui/material/DialogTitle";
 import DialogContent from "@mui/material/DialogContent";
 import DialogActions from "@mui/material/DialogActions";
-import DeleteForeverIcon from "@mui/icons-material/DeleteForever";
 import HomeIcon from "@mui/icons-material/Home";
+import ReplayIcon from "@mui/icons-material/Replay";
 import { useNavigate } from "react-router-dom";
 
 export const ISCContext = createContext(undefined);
@@ -143,11 +143,11 @@ const IndicatorSpecificationCard = () => {
             step:"0"
           },
           manual:{
-            locked:true,
+            locked: true,
             openPanel: false,
           },
           upload:{
-            locked:true,
+            locked: true,
             openPanel: false,
           },
         };
@@ -254,10 +254,10 @@ const IndicatorSpecificationCard = () => {
       visualization: { locked: true, openPanel: false, step: "0" },
       method: { locked: true, type: "", openPanel: false, step: "0" },
       dataset: { locked: true, openPanel: false, step: "0" },
-      finalize: { locked: true, openPanel: false, step: "5" },
+      finalize: { locked: true, openPanel: false, step: "6" },
     });
     sessionStorage.removeItem("session_isc");
-    enqueueSnackbar("All was reset.", { variant: "success" });
+    enqueueSnackbar("All inputs have been cleared.", { variant: "success" });
   };
 
   // Neue Handler für Dialog
@@ -272,13 +272,18 @@ const IndicatorSpecificationCard = () => {
     <>
       {/* Bestätigungsdialog */}
       <Dialog open={openDialog} onClose={handleCloseDialog}>
-        <DialogTitle>Are you sure you want to RESET?</DialogTitle>
+        <DialogTitle>Clear All Inputs</DialogTitle>
+        <DialogContent>
+          <Typography>
+            Are you sure you want to clear all inputs? This action cannot be undone.
+          </Typography>
+        </DialogContent>
         <DialogActions>
-          <Button onClick={handleCloseDialog} color="primary">
-            No
+          <Button onClick={handleCloseDialog}>
+            Cancel
           </Button>
-          <Button onClick={handleConfirmDelete} color="error" variant="contained">
-            Yes
+          <Button onClick={handleConfirmDelete} color="primary" variant="contained">
+            Clear
           </Button>
         </DialogActions>
       </Dialog>
@@ -294,16 +299,17 @@ const IndicatorSpecificationCard = () => {
           justifyContent: "space-between",
           alignItems: "center",
           width: "100%",
-          padding: "12px 24px 12px 24px",
+          padding: "12px 24px",
           borderBottom: "1px solid #eee",
         }}
       >
         <div style={{ display: "flex", alignItems: "center" }}>
-          <Tooltip title="ISC Dashboard" placement="bottom">
+          <Tooltip title="Go to Dashboard" placement="bottom">
             <IconButton
               color="primary"
               onClick={() => navigate("/isc")}
-              sx={{ p: 0.5, mr: 1 }}
+              sx={{ p: 1, mr: 1, width: 40, height: 40 }}
+              aria-label="Go to Dashboard"
             >
               <HomeIcon />
             </IconButton>
@@ -312,22 +318,20 @@ const IndicatorSpecificationCard = () => {
             ISC Creator
           </Typography>
         </div>
-        <Tooltip title="Reset All" placement="bottom">
-          <Button
-            variant="outlined"
+        <Tooltip title="Clear All Inputs" placement="bottom">
+          <IconButton
             color="error"
             onClick={handleOpenDialog}
             sx={{
-              ml: 2,
-              minWidth: 0,
+              p: 1,
+              width: 40,
+              height: 40,
               borderRadius: "50%",
-              padding: "10px",
-              width: "40px",
-              height: "40px",
             }}
+            aria-label="Clear All Inputs"
           >
-            <DeleteForeverIcon />
-          </Button>
+            <ReplayIcon />
+          </IconButton>
         </Tooltip>
       </div>
 
@@ -369,7 +373,7 @@ const IndicatorSpecificationCard = () => {
             </Grid>
           )}
           {/* Adding the new step "Method" */}
-          {lockedStep.dataset.step === '4' && lockedStep?.method.type !== ""  &&(
+          {lockedStep.dataset.step === "4" && lockedStep?.method.type !== ""  && (
             <Grid size={{ xs: 12 }}>
               <Method />
             </Grid>
@@ -380,7 +384,7 @@ const IndicatorSpecificationCard = () => {
               <Dataset />
             </Grid>
           )}
-          {lockedStep.dataset.step === '3' && lockedStep.method.type !== ""  &&(
+          {lockedStep.dataset.step === "3" && lockedStep?.method.type !== ""  && (
             <Grid size={{ xs: 12 }}>
               <Method />
             </Grid>

--- a/openlab/frontend/src/pages/indicator-specification-cards/creator/indicator-specification-card.jsx
+++ b/openlab/frontend/src/pages/indicator-specification-cards/creator/indicator-specification-card.jsx
@@ -312,7 +312,7 @@ const IndicatorSpecificationCard = () => {
             ISC Creator
           </Typography>
         </div>
-        <Tooltip title="Reset ISC" placement="bottom">
+        <Tooltip title="Reset All" placement="bottom">
           <Button
             variant="outlined"
             color="error"

--- a/openlab/frontend/src/setup/routes-manager/app-routes.jsx
+++ b/openlab/frontend/src/setup/routes-manager/app-routes.jsx
@@ -115,7 +115,7 @@ const AppRoutes = () => {
                       path="/dashboard"
                       element={
                         <PrivateRoute
-                          component={<Dashboard />}
+                          component={<Home />}
                           allowedRoles={[
                             RoleTypes.user,
                             RoleTypes.userWithoutLRS,


### PR DESCRIPTION
- changed reset button to circular arrow
- fixed the numbering of steps 1-6
- consistent dialog design
- hide next steps when going back to step 2 and choosing a different path (Visualization or Dataset)
- x-axis will only show data options either categorical or ordinal based on chart type, not both
- clearer missing data warning
